### PR TITLE
Check for the will-change: 'transform' background image performance hack

### DIFF
--- a/HTMLCS.js
+++ b/HTMLCS.js
@@ -671,14 +671,15 @@ var HTMLCS = new function()
          *
          * @returns {Object}
          */
-        this.style = function(element) {
+        this.style = function(element, pseudo) {
             var computedStyle = null;
             var window        = this.getElementWindow(element);
+            var pseudo        = pseudo || null;
 
             if (element.currentStyle) {
                 computedStyle = element.currentStyle;
             } else if (window.getComputedStyle) {
-                computedStyle = window.getComputedStyle(element, null);
+                computedStyle = window.getComputedStyle(element, pseudo);
             }
 
             return computedStyle;

--- a/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3_Contrast.js
+++ b/Standards/WCAG2AAA/Sniffs/Principle1/Guideline1_4/1_4_3_Contrast.js
@@ -98,6 +98,23 @@ var HTMLCS_WCAG2AAA_Sniffs_Principle1_Guideline1_4_1_4_3_Contrast = {
                             if (parentStyle.position == 'absolute') {
                                 isAbsolute = true;
                             }
+                            
+                            //Search for the smooth scrolling willChange: 'transform' background hack
+                            //See http://fourkitchens.com/blog/article/fix-scrolling-performance-css-will-change-property
+                            var beforeStyle = HTMLCS.util.style(parent, ':before');
+                            if (
+                                beforeStyle
+                                && beforeStyle.position == 'fixed'
+                                && beforeStyle.willChange == 'transform'
+                                //Make sure it is trying to cover the entire content area
+                                && beforeStyle.width == parentStyle.width
+                                && parseInt(beforeStyle.height, 10) <= parseInt(parentStyle.height, 10)
+                                //And finally it needs a background image
+                                && beforeStyle.backgroundImage !== 'none'
+                            ) {
+                                hasBgImg = true;
+                                break;
+                            }
 
                             parent = parent.parentNode;
                         }//end while


### PR DESCRIPTION
This was throwing a false positive in some cases, where it should trigger a manual check instead. The workaround is outlined in this post http://fourkitchens.com/blog/article/fix-scrolling-performance-css-will-change-property

It has been seen in the wild at UNL at http://unlcms.unl.edu/businessandfinance/parking-2/athletic-events-parking

While I personally think that the performance issue should be addressed in the browser rather than a workaround like this, we should probably still check for it.